### PR TITLE
Update redis version and download link

### DIFF
--- a/install_redis
+++ b/install_redis
@@ -1,7 +1,7 @@
-VERSION="2.6.14"
+VERSION="2.8.17"
 echo "-----------------------------------------------------------------------"
 echo "Now will install Redis $VERSION..."
-curl -O http://redis.googlecode.com/files/redis-$VERSION.tar.gz
+curl -O http://download.redis.io/releases/redis-$VERSION.tar.gz
 tar zxf redis-$VERSION.tar.gz
 cd redis-$VERSION
 make && sudo make install


### PR DESCRIPTION
Can not access to googlecode.com and install false.
So change the download link to redis.io.
