### PR TITLE
need to downloading the signatures

### DIFF
--- a/install_rvm
+++ b/install_rvm
@@ -1,5 +1,6 @@
 echo "Install RVM"
 echo ""
+gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
 \curl -L https://get.rvm.io | bash -s stable
 echo '[[ -s "$HOME/.rvm/scripts/rvm" ]] && . "$HOME/.rvm/scripts/rvm"' >>~/.bashrc
 source ~/.bashrc


### PR DESCRIPTION
出现了这个问题：
Downloading https://github.com/wayneeseguin/rvm/archive/1.26.0.tar.gz
Downloading https://github.com/wayneeseguin/rvm/releases/download/1.26.0/1.26.0.tar.gz.asc
gpg: Signature made Wed 29 Oct 2014 12:52:06 PM UTC using RSA key ID BF04FF17
gpg: Can't check signature: public key not found
GPG signature verification failed for '/home/vagrant/.rvm/archives/rvm-1.26.0.tgz' - 'https://github.com/wayneeseguin/rvm/releases/downloa6.0.tar.gz.asc'!
try downloading the signatures:

    gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3

they can be compared with:

    https://rvm.io/mpapis.asc
    https://keybase.io/mpapis

按照提示需要进行签名的下载
因此在下载运行 sh 之前加入此语句：gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3

经过测试，没加之前会安装失败，加了之后，安装成功了。